### PR TITLE
SRE-2829: Pin github actions to commit hash

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5.3.0
       with:
         go-version: 1.20.x
 

--- a/.github/actions/cache/golang/action.yml
+++ b/.github/actions/cache/golang/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Restore Go mod (pkg)
       if: ${{ inputs.refresh-go-cache != 'true' }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       with:
         path: |          
           ~/go/pkg/mod
@@ -26,7 +26,7 @@ runs:
 
     - name: Restore Go build (test)
       if: ${{ inputs.refresh-go-cache != 'true' }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       with:
         path: |
           ~/.cache/go-build
@@ -37,7 +37,7 @@ runs:
 
     - name: Cache Go mod (pkg)
       if: ${{ inputs.refresh-go-cache == 'true' }}
-      uses: actions/cache@v3
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       with:
         path: |
           ~/go/pkg/mod
@@ -48,7 +48,7 @@ runs:
 
     - name: Cache Go build (test)
       if: ${{ inputs.refresh-go-cache == 'true' }}
-      uses: actions/cache@v3
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       with:
         path: |
           ~/.cache/go-build

--- a/.github/actions/cache/golangci-lint/action.yml
+++ b/.github/actions/cache/golangci-lint/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache golangci-lint
-      uses: actions/cache@v3
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       id: cache-golangci-lint
       with:
         path: ~/go/bin/golangci-lint
@@ -31,7 +31,7 @@ runs:
 
     - name: Restore golangci-lint analysis cache
       if: ${{ inputs.refresh-analysis-cache != 'true' }}
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       with:
         path: ~/.cache/golangci-lint
         # This technique will make the cache key unique to the commit SHA,
@@ -42,7 +42,7 @@ runs:
 
     - name: Cache golangci-lint analysis cache
       if: ${{ inputs.refresh-analysis-cache == 'true' }}
-      uses: actions/cache@v3
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       with:
         path: ~/.cache/golangci-lint
         # This technique will make the cache key unique to the commit SHA,

--- a/.github/actions/push/action.yaml
+++ b/.github/actions/push/action.yaml
@@ -34,7 +34,7 @@ runs:
         github-token: ${{ inputs.github-token }}
 
     - name: Restore Go mod (pkg)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       with:
         path: "~/go/pkg/mod"
         key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}-${{ github.sha }}-${{ github.run_id }}
@@ -44,7 +44,7 @@ runs:
           ${{ runner.os }}-gomod-
 
     - name: Restore Go build (test)
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # pin@v4.2.2
       with:
         path: "~/.cache/go-build"
         key: ${{ runner.os }}-gobuild-${{ hashFiles('**/go.sum') }}-${{ github.sha }}-${{ github.run_id }}

--- a/.github/actions/push/action.yaml
+++ b/.github/actions/push/action.yaml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # pin@v3.4.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -28,7 +28,7 @@ runs:
 
     - name: Extract Docker metadata
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # pin@v5.7.0
       with:
         images: ghcr.io/${{ github.repository }}/s
         github-token: ${{ inputs.github-token }}
@@ -61,7 +61,7 @@ runs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # pin@v3.10.0
       with:
         version: latest
         endpoint: builders

--- a/.github/actions/rewind/action.yaml
+++ b/.github/actions/rewind/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5.3.0
       with:
         go-version: 1.20.x
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
       - name: Tags
         shell: bash

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,19 +13,19 @@ jobs:
     runs-on: ubuntu-20-04-4-cores
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Invariants
         shell: bash
         run: ./.github/scripts/invariants.sh
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.82.7
+        uses: trufflesecurity/trufflehog@12164e38f0f1b673ab0594c7d94daf71b0be6823 # pin@3.88.17
 
   bootstrap:
     name: Local E2E Tests
     runs-on: ubuntu-20-04-4-cores
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Cache modules
         uses: ./.github/actions/cache/golang
       - uses: ./.github/actions/bootstrap
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-20-04-4-cores
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - name: Cache modules
         uses: ./.github/actions/cache/golang
       - uses: ./.github/actions/rewind
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20-04-4-cores
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
         with:
           fetch-depth: 0 # We need the full history to get the base commit in order to compute the diff in golanci-lint
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5.3.0
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-20-04-4-cores
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5.3.0
         with:
           go-version: 1.20.x

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # We need the full history to get the base commit in order to compute the diff in golanci-lint
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5.3.0
         with:
           go-version: 1.20.x
       - name: Cache modules
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # pin@v5.3.0
         with:
           go-version: 1.20.x
       - name: Cache modules

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4.2.2
 
       - name: Set Release Tag
         run: echo "TAG=$(echo ${GITHUB_REF} | sed 's/refs\/tags\///')" >> $GITHUB_ENV


### PR DESCRIPTION
Ensures we are pinned to the commit hash and not the tag (which is mutable) as recommended by github