### PR TITLE
SRE-2829: Pin build-push-action

### DIFF
--- a/.github/actions/push/action.yaml
+++ b/.github/actions/push/action.yaml
@@ -67,7 +67,7 @@ runs:
         endpoint: builders
 
     - name: Build and push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # pin@v6.15.0
       with:
         context: .
         platforms: linux/amd64


### PR DESCRIPTION
This was missed in the prior PR update, just ensuring its also pinned as per our standard now.