### PR TITLE
Return 413 when request too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0-beta.16]
+
+- Return `413` status code instead of `500` when RPC request body exceeds size limit 
+
 ## [v1.0.0-beta.15]
 
 - Reduce noisy logs

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
 	VersionPatch = 0         // Patch version component of the current release
-	VersionMeta  = "beta.15" // Version metadata to append to the version string
+	VersionMeta  = "beta.16" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
# Summary

When the request is too large, return the more appropriate 413 status code rather than 5xx.

## Checklist

<!---  Please check these as required. If you believe they are not necessary, keep them unchecked (do not delete them). -->

- [ ] New features added
- [x] Bugs fixed
- [ ] Unit tests added or updated
- [ ] E2E tests added or updated
- [ ] CI updated
