### PR TITLE
feat: add support for arm64 docker images

### DIFF
--- a/.github/actions/push/action.yaml
+++ b/.github/actions/push/action.yaml
@@ -76,7 +76,7 @@ runs:
       uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # pin@v6.15.0
       with:
         context: .
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         file: ${{ inputs.dockerfile }}
         push: true
         build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
# Summary

The existing CI/CD pipeline only built Docker images for x86_64 (amd64) architecture. Adding arm64 enables the images to run natively on ARM-based systems like Apple Silicon Macs, AWS Graviton instances, and other ARM servers—improving performance and compatibility for users on those platforms.

## Checklist

<!---  Please check these as required. If you believe they are not necessary, keep them unchecked (do not delete them). -->

- [ ] New features added
- [ ] Bugs fixed
- [ ] Unit tests added or updated
- [ ] E2E tests added or updated
- [x] CI updated
