### PR TITLE
Add configurable platforms to Docker push action and enable multi-arch for releases

### DIFF
--- a/.github/actions/push/action.yaml
+++ b/.github/actions/push/action.yaml
@@ -15,6 +15,11 @@ inputs:
   build-args:
     required: false
     type: string
+  platforms:
+    required: false
+    type: string
+    default: "linux/amd64"
+    description: "Comma separated list of target platforms (e.g. linux/amd64,linux/arm64)"
 
 outputs:
   digest:
@@ -76,7 +81,7 @@ runs:
       uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # pin@v6.15.0
       with:
         context: .
-        platforms: linux/amd64
+        platforms: ${{ inputs.platforms }}
         file: ${{ inputs.dockerfile }}
         push: true
         build-args: ${{ inputs.build-args }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           tags: "ghcr.io/${{ github.repository }}/immutable-geth:latest,ghcr.io/${{ github.repository }}/immutable-geth:${{ env.TAG }}"
-      
+          platforms: linux/amd64,linux/arm64
+
       - name: Attest
         uses: actions/attest-build-provenance@v2
         id: attest


### PR DESCRIPTION
Makes the Docker push composite action accept a configurable `platforms` input and uses it to build multi-architecture images for releases.